### PR TITLE
支持 Spring Boot 3.X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 //apply from: './deploy.gradle'
 apply from: './publish.gradle'
 group = 'com.github.taptap'
-version = '1.3'
+version = '1.3.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 configurations {
@@ -47,4 +47,3 @@ jar {
 test {
     useJUnitPlatform()
 }
-

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.taptap.ratelimiter.configuration.RateLimiterAutoConfiguration


### PR DESCRIPTION
在 spring-projects/spring-boot#29699 ，spring-projects/spring-boot#29872 等 issue 中提到 Spring Boot 3.X 计划（并最终）移除 `spring.factories` 支持，转而使用 `/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`。

添加这个文件使项目支持 Spring Boot 3.X，并变更版本号到 `1.3.1-SNAPSHOT`。